### PR TITLE
feat: 新增 i18n ESLint 規則

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,4 +1,5 @@
 import antfu from '@antfu/eslint-config'
+import vueI18n from '@intlify/eslint-plugin-vue-i18n'
 
 export default antfu(
   {
@@ -7,6 +8,22 @@ export default antfu(
     rules: {
       'vue/no-mutating-props': 'off',
       'style/type-generic-spacing': 'off',
+    },
+  },
+).append(
+  vueI18n.configs.recommended,
+  {
+    settings: {
+      'vue-i18n': {
+        localeDir: 'locales/*.json',
+      },
+    },
+    rules: {
+      '@intlify/vue-i18n/no-missing-keys': 'error',
+      '@intlify/vue-i18n/no-raw-text': 'off',
+      '@intlify/vue-i18n/no-deprecated-modulo-syntax': 'off',
+      '@intlify/vue-i18n/key-format-style': 'error',
+      '@intlify/vue-i18n/no-missing-keys-in-other-locales': 'error',
     },
   },
 )

--- a/locales/en.json
+++ b/locales/en.json
@@ -27,6 +27,9 @@
   "header": {
     "today": "Today"
   },
+  "role": {
+    "admin": "Admin"
+  },
   "time": {
     "year": "Year",
     "month": "Month",

--- a/locales/es.json
+++ b/locales/es.json
@@ -27,6 +27,9 @@
   "header": {
     "today": "Hoy"
   },
+  "role": {
+    "admin": "Administrador"
+  },
   "time": {
     "year": "Año",
     "month": "Mes",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -27,6 +27,9 @@
   "header": {
     "today": "Aujourd'hui"
   },
+  "role": {
+    "admin": "Admin"
+  },
   "time": {
     "year": "Année",
     "month": "Mois",

--- a/locales/jp.json
+++ b/locales/jp.json
@@ -25,7 +25,10 @@
     "name": "ค้นหาชื่อ"
   },
   "header": {
-    "today": "今日は"
+    "today": "今日"
+  },
+  "role": {
+    "admin": "管理者"
   },
   "time": {
     "year": "年",

--- a/locales/th.json
+++ b/locales/th.json
@@ -27,6 +27,9 @@
   "header": {
     "today": "วันนี้"
   },
+  "role": {
+    "admin": "แอดมิน"
+  },
   "time": {
     "year": "ปี",
     "month": "เดือน",

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -25,7 +25,10 @@
     "name": "搜尋名稱"
   },
   "header": {
-    "today": "今天"
+    "today": "今日"
+  },
+  "role": {
+    "admin": "管理員"
   },
   "time": {
     "year": "年",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "preview": "vite preview",
     "release": "bumpp --commit --tag --push",
     "typecheck": "vue-tsc --noEmit",
-    "lint": "eslint 'src/**/*.{ts,vue}'",
+    "lint": "eslint .",
     "lint:fix": "eslint --fix .",
     "up": "taze major -I"
   },
@@ -40,6 +40,7 @@
     "@coreui/vue-pro": "^5.10.0",
     "@iconify-json/carbon": "^1.2.8",
     "@iconify-json/cil": "^1.2.2",
+    "@intlify/eslint-plugin-vue-i18n": "^4.0.1",
     "@intlify/unplugin-vue-i18n": "^6.0.5",
     "@types/archiver": "^6.0.3",
     "@types/node": "^22.14.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,9 @@ importers:
       '@iconify-json/cil':
         specifier: ^1.2.2
         version: 1.2.2
+      '@intlify/eslint-plugin-vue-i18n':
+        specifier: ^4.0.1
+        version: 4.0.1(eslint@9.24.0(jiti@2.4.2))(jsonc-eslint-parser@2.4.0)(vue-eslint-parser@10.1.3(eslint@9.24.0(jiti@2.4.2)))(yaml-eslint-parser@1.3.0)
       '@intlify/unplugin-vue-i18n':
         specifier: ^6.0.5
         version: 6.0.5(@vue/compiler-dom@3.5.13)(eslint@9.24.0(jiti@2.4.2))(rollup@4.34.7)(typescript@5.8.3)(vue-i18n@11.1.3(vue@3.5.13(typescript@5.8.3)))(vue@3.5.13(typescript@5.8.3))
@@ -247,6 +250,10 @@ packages:
     resolution: {integrity: sha512-81NWa1njQblgZbQHxWHpxxCzNsa3ZwvFqpUg7P+NNUU6f3UU2jBEg4OlF/J6rl8+PQGh1q6/zWScd001YwcA5A==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  '@babel/runtime@7.27.0':
+    resolution: {integrity: sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/types@7.26.9':
     resolution: {integrity: sha512-Y3IR1cRnOxOCDvMmNiym7XpXQ93iGDDPHx+Zj+NM+rg0fBaShfQLkg+hKPaZCEvg5N/LeCo4+Rj/i3FuJsIQaw==}
@@ -710,6 +717,15 @@ packages:
   '@intlify/core-base@11.1.3':
     resolution: {integrity: sha512-cMuHunYO7LE80azTitcvEbs1KJmtd6g7I5pxlApV3Jo547zdO3h31/0uXpqHc+Y3RKt1wo2y68RGSx77Z1klyA==}
     engines: {node: '>= 16'}
+
+  '@intlify/eslint-plugin-vue-i18n@4.0.1':
+    resolution: {integrity: sha512-xZKG7EvMvvumK9sdpnt6Dxa/dxV6/05/hRXIgJc0XI4l0+QUnyfdz5qXEvDm21T+OQsFN0CK/C+p0Fpra2wscQ==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      eslint: ^8.0.0 || ^9.0.0-0
+      jsonc-eslint-parser: ^2.3.0
+      vue-eslint-parser: ^10.0.0
+      yaml-eslint-parser: ^1.2.2
 
   '@intlify/message-compiler@11.1.2':
     resolution: {integrity: sha512-T/xbNDzi+Yv0Qn2Dfz2CWCAJiwNgU5d95EhhAEf4YmOgjCKktpfpiUSmLcBvK1CtLpPQ85AMMQk/2NCcXnNj1g==}
@@ -2418,6 +2434,9 @@ packages:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
 
+  is-language-code@3.1.0:
+    resolution: {integrity: sha512-zJdQ3QTeLye+iphMeK3wks+vXSRFKh68/Pnlw7aOfApFSEIOhYa8P9vwwa6QrImNNBMJTiL1PpYF0f4BxDuEgA==}
+
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
@@ -2844,6 +2863,9 @@ packages:
     resolution: {integrity: sha512-eONBZy4hm2AgxjNFd8a4nyDJnzUAH0g34xSQAwWEVGCjdZ4ZL7dKZBfq267GWP/JaS9zW62Xs2FeAdDvpHHJGQ==}
     engines: {node: '>=18'}
 
+  parse5@7.2.1:
+    resolution: {integrity: sha512-BuBYQYlv1ckiPdQi/ohiivi9Sagc9JG+Ozs0r7b/0iK3sKmrb0b9FdWdBbOdx6hBCM/F9Ir82ofnBhtZOjCRPQ==}
+
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
 
@@ -3000,6 +3022,9 @@ packages:
   refa@0.12.1:
     resolution: {integrity: sha512-J8rn6v4DBb2nnFqkqwy6/NnTYMcgLA+sLr0iIO41qpv0n+ngb7ksag2tMRl0inb1bbO/esUwzW1vbJi7K0sI0g==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
+  regenerator-runtime@0.14.1:
+    resolution: {integrity: sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==}
 
   regexp-ast-analysis@0.7.1:
     resolution: {integrity: sha512-sZuz1dYW/ZsfG17WSAG7eS85r5a0dDsvg+7BiiYR5o6lKCAtUrEwdmRmaGF6rwVj3LcmAeYkOWKEPlbPzN3Y3A==}
@@ -3203,6 +3228,10 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  synckit@0.10.3:
+    resolution: {integrity: sha512-R1urvuyiTaWfeCggqEvpDJwAlDVdsT9NM+IP//Tk2x7qHCkSvBk/fwFgw/TLAHzZlrAnnazMcRw0ZD8HlYFTEQ==}
+    engines: {node: ^14.18.0 || >=16.0.0}
 
   synckit@0.6.2:
     resolution: {integrity: sha512-Vhf+bUa//YSTYKseDiiEuQmhGCoIF3CVBhunm3r/DQnYiGT4JssmnKQc44BIyOZRK2pKjXXAgbhfmbeoC9CJpA==}
@@ -3703,6 +3732,10 @@ snapshots:
     dependencies:
       '@babel/types': 7.26.9
 
+  '@babel/runtime@7.27.0':
+    dependencies:
+      regenerator-runtime: 0.14.1
+
   '@babel/types@7.26.9':
     dependencies:
       '@babel/helper-string-parser': 7.25.9
@@ -4046,6 +4079,31 @@ snapshots:
     dependencies:
       '@intlify/message-compiler': 11.1.3
       '@intlify/shared': 11.1.3
+
+  '@intlify/eslint-plugin-vue-i18n@4.0.1(eslint@9.24.0(jiti@2.4.2))(jsonc-eslint-parser@2.4.0)(vue-eslint-parser@10.1.3(eslint@9.24.0(jiti@2.4.2)))(yaml-eslint-parser@1.3.0)':
+    dependencies:
+      '@eslint/eslintrc': 3.3.1
+      '@intlify/core-base': 11.1.3
+      '@intlify/message-compiler': 11.1.3
+      debug: 4.4.0
+      eslint: 9.24.0(jiti@2.4.2)
+      eslint-compat-utils: 0.6.4(eslint@9.24.0(jiti@2.4.2))
+      glob: 10.4.5
+      globals: 16.0.0
+      ignore: 7.0.3
+      import-fresh: 3.3.1
+      is-language-code: 3.1.0
+      js-yaml: 4.1.0
+      json5: 2.2.3
+      jsonc-eslint-parser: 2.4.0
+      lodash: 4.17.21
+      parse5: 7.2.1
+      semver: 7.7.1
+      synckit: 0.10.3
+      vue-eslint-parser: 10.1.3(eslint@9.24.0(jiti@2.4.2))
+      yaml-eslint-parser: 1.3.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@intlify/message-compiler@11.1.2':
     dependencies:
@@ -5950,6 +6008,10 @@ snapshots:
     dependencies:
       is-extglob: 2.1.1
 
+  is-language-code@3.1.0:
+    dependencies:
+      '@babel/runtime': 7.27.0
+
   is-number@7.0.0: {}
 
   is-stream@2.0.1: {}
@@ -6529,6 +6591,10 @@ snapshots:
       index-to-position: 1.0.0
       type-fest: 4.38.0
 
+  parse5@7.2.1:
+    dependencies:
+      entities: 4.5.0
+
   path-browserify@1.0.1: {}
 
   path-exists@4.0.0: {}
@@ -6674,6 +6740,8 @@ snapshots:
   refa@0.12.1:
     dependencies:
       '@eslint-community/regexpp': 4.12.1
+
+  regenerator-runtime@0.14.1: {}
 
   regexp-ast-analysis@0.7.1:
     dependencies:
@@ -6886,6 +6954,11 @@ snapshots:
       has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  synckit@0.10.3:
+    dependencies:
+      '@pkgr/core': 0.2.4
+      tslib: 2.8.1
 
   synckit@0.6.2:
     dependencies:

--- a/src/components/TheHeader.vue
+++ b/src/components/TheHeader.vue
@@ -22,7 +22,7 @@ const currentTime = computed(() => format(now.value, 'HH:mm:ss'))
     </RouterLink>
     <div h-full flex="~ items-center" gap-x-4>
       <div text="xl">
-        Admin
+        {{ t('role.admin') }}
       </div>
       <div bg="[#8A9192]" h-full w-px />
       <div h-full flex="~ col items-end justify-between" text-sm>


### PR DESCRIPTION
此 PR 新增了 i18n Eslint 規則，用來檢查翻譯檔案。

主要可以偵測

- 缺少的翻譯 key（[@intlify/vue-i18n/no-missing-keys](https://eslint-plugin-vue-i18n.intlify.dev/rules/no-missing-keys.html), [@intlify/vue-i18n/no-missing-keys-in-other-locales](https://eslint-plugin-vue-i18n.intlify.dev/rules/no-missing-keys-in-other-locales.html)）
- 重複的 key 格式錯誤（[@intlify/vue-i18n/key-format-style](https://eslint-plugin-vue-i18n.intlify.dev/rules/key-format-style.html)）

這些規則有助於確保翻譯檔案的完整性與一致性，減少遺漏或格式錯誤的情況。
規則細節可參考官方文件：https://eslint-plugin-vue-i18n.intlify.dev/rules/